### PR TITLE
Update echo-server.ts

### DIFF
--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -177,8 +177,7 @@ export class EchoServer {
             let privateSocket = socket.join(data.channel);
 
             if (this.isPresenceChannel(data.channel) && res.channel_data) {
-                let member = JSON.parse(res.channel_data);
-                member.socketId = socket.id;
+                let member = res.channel_data;
                 this.presenceChannelEvents(data.channel, privateSocket, member);
             }
         }, error => { }).then(() => this.sendSocketId(data, socket.id));


### PR DESCRIPTION
res.channel_data is already an object, so trying to parse it was causing an issue. Also I don't think we want to send member.socketId down to the client since it reveals the socket ID down to other people in the channel. Not sure if that matters security wise but just seemed unneeded.