### PR TITLE
Fix a problem where same user at same presence channel are reported o…

### DIFF
--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -318,7 +318,7 @@ export class EchoServer {
         this.getPresenceChannelMembers(channel).then(members => {
             members = members || [];
             members.push(newMember);
-            members = _.uniqBy(members.reverse(), Object.keys(newMember)[0]);
+    	    members = _.uniqBy(members.reverse(), 'socketId');
 
             this.store(channel + ':members', members);
             this.emitPresenceEvents(socket, channel, members, member, 'add');


### PR DESCRIPTION
Use case:

We have a presence channel for /x/1234 route,
There are 2 user, John and Paul,

Paul has this url open one time;
John have 2 tabs with this url opened;

When John close first tab, they are removed for that presence channel, but they are at another tab yet.

When same user joing on twice on same presence channel, only one time they are tracked.. another
connections - tabs - are forgeted.

It's up to you ( with vue, eg ) to handle the 'duplication' of same user (2 tabs ),
and handle the leaving event.


