### PR TITLE
Laravel Debugbar conflicts with authentication request

### DIFF
--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -468,6 +468,7 @@ export class EchoServer {
      */
     protected prepareHeaders(socket: any, options: any): any {
         options.headers['Cookie'] = socket.request.headers.cookie;
+        // Send request as if it were sent as an AJAX request
         options.headers['X-Requested-With'] = 'XMLHttpRequest';
 
         return options.headers;

--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -468,6 +468,7 @@ export class EchoServer {
      */
     protected prepareHeaders(socket: any, options: any): any {
         options.headers['Cookie'] = socket.request.headers.cookie;
+        options.headers['X-Requested-With'] = 'XMLHttpRequest';
 
         return options.headers;
     }


### PR DESCRIPTION
Hello,

First and foremost, thanks a ton for working on this awesome project.  I was afraid I'd end up trying to have to squeeze myself into the free tier of Pusher but you've saved the day.

Anyways, I've found that if you are using the excellent [Laravel Debugbar Package](https://github.com/barryvdh/laravel-debugbar) package with response injection enabled, it tries to inject itself into the broadcasting auth response, which cause the `JSON.parse` method to fail in the severRequest (not sure if that's a typo!) method.  

By sending the request with the `X-Requested-With` header set to `XMLHttpRequest`, it's treated as an AJAX request and there is no response injection done by the Debugbar package.  I've tested and there seems to be no side-effects of having the request come in as an AJAX request versus the normal POST request.