### PR TITLE
Fix checking for http via host option.

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -46,7 +46,7 @@ export class Server {
      */
     serverProtocol(): Promise<any> {
         return new Promise((resolve, reject) => {
-            if ((/(https)\:\/\//).test(this.options.host)) {
+            if (this.options.protocol == 'https') {
                 this.secure().then(() => {
                     resolve(this.httpServer(true));
                 }, error => reject(error));


### PR DESCRIPTION
When checking for which http protocol to use, the "host" option in the json file is tested to see if it starts with `https` or `http`

However, if the host option DOES start with either of those, the script throws a `Error: getaddrinfo ENOTFOUND` error. See [tech info here](http://stackoverflow.com/a/17691556/659786).

So removing the protocol from the `host` options means we must use something else to check for http(s). This patch uses the `protocol` option in the json file. First suggested by https://github.com/Thaars