### PR TITLE
Better feedback from initialisation process

### DIFF
--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -29,7 +29,8 @@ export class EchoServer {
         referrers: [],
         socketio: {},
         sslCertPath: '',
-        sslKeyPath: ''
+        sslKeyPath: '',
+        verbose: false
     };
 
     /**
@@ -83,6 +84,13 @@ export class EchoServer {
     private redisReady: boolean = false;
 
     /**
+     * Function to execute when server is up and running.
+     *
+     * @type {Function}
+     */
+    private onReady: Function;
+
+    /**
      * Create a new instance.
      */
     constructor() { }
@@ -93,7 +101,10 @@ export class EchoServer {
      * @param  {Object} config
      * @return {void}
      */
-    run(options: any): void {
+    run(options: any, callback?: Function): void {
+        if (callback) {
+            this.onReady = callback;
+        }
         this.options = Object.assign(this.defaultOptions, options);
         this.startup();
         this.server = new Server(this.options);
@@ -148,6 +159,9 @@ export class EchoServer {
     onComponentReady(): void {
         if (this.isReady()) {
             Log.info('\nServer ready!\n');
+            if (typeof this.onReady === 'function') {
+                this.onReady(this);
+            }
         }
     }
 
@@ -205,6 +219,10 @@ export class EchoServer {
      * @return {void}
      */
     broadcast(channel: string, message: any): boolean {
+        if (this.options.verbose) {
+            console.log(channel, (message.hasOwnProperty('event') ? message.event : message));
+        }
+
         if (message.socket && this.find(message.socket)) {
             return this.toOthers(this.find(message.socket), channel, message);
         } else {

--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -99,9 +99,9 @@ export class EchoServer {
         this.server = new Server(this.options);
 
         this.server.init().then(io => {
+            this.ioReady = true;
+            this.onComponentReady();
             this.init(io).then(() => {
-                this.ioReady = true;
-                this.onComponentReady();
             }, error => Log.error(error));
         }, error => Log.error(error));
     }

--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -70,17 +70,17 @@ export class EchoServer {
     /**
      * @type {boolean}
      */
-    private redisReady: boolean = false;
-
-    /**
-     * @type {boolean}
-     */
     private httpReady: boolean = false;
 
     /**
      * @type {boolean}
      */
     private ioReady: boolean = false;
+
+    /**
+     * @type {boolean}
+     */
+    private redisReady: boolean = false;
 
     /**
      * Create a new instance.
@@ -157,7 +157,7 @@ export class EchoServer {
      * @returns {boolean}
      */
     isReady(): boolean {
-        return this.redisReady && this.httpReady && this.ioReady;
+        return this.httpReady && this.ioReady && this.redisReady;
     }
 
     /**

--- a/src/subscribers/http-subscriber.ts
+++ b/src/subscribers/http-subscriber.ts
@@ -15,7 +15,7 @@ export class HttpSubscriber implements Subscriber {
      *
      * @return {void}
      */
-    subscribe(callback): void {
+    subscribe(onMessage, onReady?): void {
         this.http.on('request', (req, res) => {
             let body: any = [];
 
@@ -26,7 +26,7 @@ export class HttpSubscriber implements Subscriber {
 
                 res.on('error', (error) => Log.error(error));
                 req.on('data', (chunk) => body.push(chunk))
-                    .on('end', () => this.handleData(req, res, body, callback));
+                    .on('end', () => this.handleData(req, res, body, onMessage));
             } else {
                 if (url.parse(req.url).pathname != '/socket.io/') {
                     res.end();
@@ -35,6 +35,9 @@ export class HttpSubscriber implements Subscriber {
         });
 
         Log.success('Listening for http events...');
+        if (typeof onReady === 'function') {
+            onReady(this);
+        }
     }
 
     /**

--- a/src/subscribers/redis-subscriber.ts
+++ b/src/subscribers/redis-subscriber.ts
@@ -22,14 +22,17 @@ export class RedisSubscriber implements Subscriber {
      *
      * @return {void}
      */
-    subscribe(callback): void {
+    subscribe(onMessage, onReady?): void {
         this._redis.psubscribe('*', (err, count) => {
             Log.success('Listening for redis events...');
+            if (typeof onReady === 'function') {
+                onReady(this);
+            }
         });
         this._redis.on('pmessage', (subscribed, channel, message) => {
             message = JSON.parse(message);
 
-            callback(channel, message);
+            onMessage(channel, message);
         });
     }
 }

--- a/src/subscribers/redis-subscriber.ts
+++ b/src/subscribers/redis-subscriber.ts
@@ -23,13 +23,13 @@ export class RedisSubscriber implements Subscriber {
      * @return {void}
      */
     subscribe(callback): void {
-        this._redis.psubscribe('*', (err, count) => { });
+        this._redis.psubscribe('*', (err, count) => {
+            Log.success('Listening for redis events...');
+        });
         this._redis.on('pmessage', (subscribed, channel, message) => {
             message = JSON.parse(message);
 
             callback(channel, message);
         });
-
-        Log.success('Listening for redis events...');
     }
 }

--- a/src/subscribers/subscriber.ts
+++ b/src/subscribers/subscriber.ts
@@ -2,8 +2,9 @@ export interface Subscriber {
     /**
      * Subscribe to incoming events.
      *
-     * @param  {Function} callback
+     * @param  {Function} onMessage
+     * @param  {Function} onReady
      * @return {void}
      */
-    subscribe(callback: Function): void;
+    subscribe(onMessage: Function, onReady?: Function): void;
 }


### PR DESCRIPTION
Previously if Redis was unable to connect it would fail silently and still say "Server Ready".
Now it only displays the Server Ready message once the http server, socket.io, and Redis are initialised successfully.