### PR TITLE
fix compile watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "compile": "tsc",
-    "compile watch": "tsc -w",
+    "compile:watch": "tsc -w",
     "prepublish": "npm run compile"
   },
   "dependencies": {


### PR DESCRIPTION
Running `npm run compile watch` didn't work, would result in running `tsc watch` not `tsc -w`