### PR TITLE
Add uws as optional dependancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,19 @@ While presence channels contain a list of users, there will be instances where a
 See the official Laravel documentation for more information. <https://laravel.com/docs/5.3/broadcasting#introduction>
 
 ### Tips
-
+#### Socket.io client library
 You can include the socket.io client library from your running server. For example, if your server is running at `app.dev:6001` you should be able to
 add a script tag to your html like so:
 
 `<script src="//app.dev:6001/socket.io/socket.io.js"></script>`
+
+#### Better performance with [µWebSockets](https://github.com/uWebSockets/uWebSockets)
+For extra performance, you can use the faster `uws` engine, instead of `ws`, by setting this `wsEngine` option for Socket.IO:
+
+```js
+"socketio": {
+    "wsEngine": "uws"
+},
+```
+
+See https://github.com/uWebSockets/uWebSockets for more information.

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ add a script tag to your html like so:
 `<script src="//app.dev:6001/socket.io/socket.io.js"></script>`
 
 #### Better performance with [µWebSockets](https://github.com/uWebSockets/uWebSockets)
-For extra performance, you can use the faster `uws` engine, instead of `ws`, by setting this `wsEngine` option for Socket.IO:
+For extra performance, you can use the faster `uws` engine instead of `ws`, by setting the `wsEngine` option for Socket.IO in `laravel-echo-server.json`:
 
 ```js
 "socketio": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "sqlite3": "^3.1.4",
     "yargs": "^5.0.0"
   },
+  "optionalDependencies": {
+    "uws": "0.12.0"
+  },
   "devDependencies": {
     "@types/node": "^6.0.45",
     "typescript": "^2.0.3"


### PR DESCRIPTION
https://github.com/uWebSockets/uWebSockets claims to be a lot faster then the default 'ws' websocket implementation. It's possible to replace this, but I think we need to add it as a dependency to be able to use it directly.  It's added as optional dependency so it should not fail if it can't install it (don't know why it should), based on https://github.com/socketio/engine.io/pull/459

It should be the default in engine.io v2, but not sure how long that's away :)