### PR TITLE
Emit subscription errors

### DIFF
--- a/src/channels/channel.ts
+++ b/src/channels/channel.ts
@@ -138,7 +138,14 @@ export class Channel {
             }
 
             this.onJoin(socket, data.channel);
-        }, error => Log.error(error));
+        }, error => {
+            Log.error(error.reason);
+
+            this.io
+                .sockets
+                .to(socket.id)
+                .emit('subscription_error', data.channel, error.status);
+        });
     }
 
     /**

--- a/src/channels/private-channel.ts
+++ b/src/channels/private-channel.ts
@@ -64,14 +64,14 @@ export class PrivateChannel {
 
                     Log.error(error);
 
-                    reject('Error sending authentication request.');
+                    reject({reason: 'Error sending authentication request.', status: 0});
                 } else if (response.statusCode !== 200) {
                     if (this.options.devMode) {
                         Log.warning(`[${new Date().toLocaleTimeString()}] - ${socket.id} could not be authenticated for ${options.form.channel_name}`);
                         Log.error(response.body);
                     }
 
-                    reject('Client can not be authenticated, got HTTP status ' + response.statusCode);
+                    reject({reason: 'Client can not be authenticated, got HTTP status ' + response.statusCode, status: response.statusCode});
                 } else {
                     if (this.options.devMode) {
                         Log.info(`[${new Date().toLocaleTimeString()}] - ${socket.id} authenticated for: ${options.form.channel_name}`);


### PR DESCRIPTION
On subscription errors, emit an event with the status code.

```js
 channel.on('subscription_error', function(status){
     alert('Error: ' + status );
})
```

Can be used to show an error message, refresh the page etc. Fixes #91 