### PR TITLE
Allow dynamic authHost

### DIFF
--- a/src/channels/private-channel.ts
+++ b/src/channels/private-channel.ts
@@ -26,7 +26,7 @@ export class PrivateChannel {
      */
     authenticate(socket: any, data: any): Promise<any> {
         let options = {
-            url: this.authHost() + this.options.authEndpoint,
+            url: this.authHost(socket) + this.options.authEndpoint,
             form: { channel_name: data.channel },
             headers: (data.auth && data.auth.headers) ? data.auth.headers : {},
             rejectUnauthorized: false
@@ -36,11 +36,24 @@ export class PrivateChannel {
     }
 
     /**
+     * Is the socket source listed in the allowedSourceList array
+     * defined in the laravel-echo-server.json file?
+     *
+     * @return {boolean}
+     */
+    protected socketIsFromApprovedSource(socket): boolean {
+        return this.options.allowedSourceList.indexOf(socket.conn.request.headers.origin) !== -1;
+    }
+
+    /**
      * Get the auth endpoint.
      *
      * @return {string}
      */
-    protected authHost(): string {
+    protected authHost(socket): string {
+        if(this.options.authHost === '<source>' && this.socketIsFromApprovedSource(socket))
+            return socket.conn.request.headers.origin;
+
         return (this.options.authHost) ?
             this.options.authHost : this.options.host;
     }

--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -17,6 +17,7 @@ export class EchoServer {
      */
     public defaultOptions: any = {
         authHost: 'http://localhost',
+        allowedSourceList: [],
         authEndpoint: '/broadcasting/auth',
         clients: [],
         database: 'redis',


### PR DESCRIPTION
if you set authHost in config to `<source>`

then you can auth from multiple domains based on socket source.

list all your domains in allowedSourceList

e.g.:

allowedSourceList: [
    ‘http://domain1.dev’,
    ‘http://domain2.dev’,
    ‘http://domain3.dev’
]