### PR TITLE
Update uws

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "yargs": "^5.0.0"
   },
   "optionalDependencies": {
-    "uws": "0.12.0"
+    "uws": "0.14.1"
   },
   "devDependencies": {
     "@types/node": "^6.0.60",


### PR DESCRIPTION
Older versions are removed; see uWebSockets/uWebSockets#551. Fixes #152 

This could be removed altogether once socket.io uses engine.io v2, which includes this dependency itself.