### PR TITLE
[Needs testing] Bump socket.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,9 @@
     "ioredis": "^1.15.1",
     "lodash": "^4.12.0",
     "request": "^2.72.0",
-    "socket.io": "^1.5.0",
+    "socket.io": "^2.0.1",
     "sqlite3": "^3.1.8",
     "yargs": "^5.0.0"
-  },
-  "optionalDependencies": {
-    "uws": "0.14.1"
   },
   "devDependencies": {
     "@types/node": "^6.0.60",


### PR DESCRIPTION
A new major version of socket.io has been released, together with the engine/parser etc.
uws is included by default now.

See https://github.com/socketio/socket.io/releases/tag/2.0.0
https://github.com/socketio/socket.io-client/releases

But I'm not sure if there is anything breaking, and if 2.x is compatible with 2.x clients only..