### PR TITLE
Allow wildcard and multi domain authHost option

### DIFF
--- a/src/channels/private-channel.ts
+++ b/src/channels/private-channel.ts
@@ -26,14 +26,8 @@ export class PrivateChannel {
      * @return {Promise<any>}
      */
     authenticate(socket: any, data: any): Promise<any> {
-        var authHost = this.authHost();
-        var referer = url.parse(socket.request.headers.referer);
-        
-        if(referer.hostname.substr(referer.hostname.indexOf('.'))===authHost)
-            authHost = referer.protocol+"//"+referer.host;
-        
         let options = {
-            url: authHost + this.options.authEndpoint,
+            url: this.authHost(socket) + this.options.authEndpoint,
             form: { channel_name: data.channel },
             headers: (data.auth && data.auth.headers) ? data.auth.headers : {},
             rejectUnauthorized: false
@@ -47,9 +41,26 @@ export class PrivateChannel {
      *
      * @return {string}
      */
-    protected authHost(): string {
-        return (this.options.authHost) ?
+    protected authHost(socket: any): string {
+        let referer: Object = url.parse(socket.request.headers.referer);
+        let authHostSelected: string = 'http://localhost';
+        let authHosts: any = (this.options.authHost) ?
             this.options.authHost : this.options.host;
+        
+        if(typeof authHosts === "string")
+            authHosts = [authHosts];
+        
+        for(let authHost of authHosts)
+        {
+            authHostSelected = authHost;
+            if(referer.hostname.substr(referer.hostname.indexOf('.')) === authHostSelected || referer.protocol + "//" + referer.host === authHostSelected || referer.host === authHostSelected)
+            {
+                authHostSelected = referer.protocol+"//"+referer.host;
+                break;
+            }
+        }
+
+        return authHostSelected;
     }
 
     /**

--- a/src/channels/private-channel.ts
+++ b/src/channels/private-channel.ts
@@ -1,6 +1,7 @@
 var request = require('request');
 import { Channel } from './channel';
 import { Log } from './../log';
+var url = require('url');
 
 export class PrivateChannel {
     /**
@@ -25,8 +26,14 @@ export class PrivateChannel {
      * @return {Promise<any>}
      */
     authenticate(socket: any, data: any): Promise<any> {
+        var authHost = this.authHost();
+        var referer = url.parse(socket.request.headers.referer);
+        
+        if(referer.hostname.substr(referer.hostname.indexOf('.'))===authHost)
+            authHost = referer.protocol+"//"+referer.host;
+        
         let options = {
-            url: this.authHost() + this.options.authEndpoint,
+            url: authHost + this.options.authEndpoint,
             form: { channel_name: data.channel },
             headers: (data.auth && data.auth.headers) ? data.auth.headers : {},
             rejectUnauthorized: false


### PR DESCRIPTION
As described in #185 allow for wildcard domain declaration in authHost option (e.g. authHost = '.myapp.com') so one use the laravel-echo-server with a multi tenant/subdomain system. The currently appropriate domain is retrived from the referer and matched with the wildcard domain declaration (if a wildcard is used). @tlaverdure please check. Thanks!

**Updated version**
See comments below...