### PR TITLE
Define Cross Domain Allow Headers To Be Set For The API

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ GET /apps/:APP_ID/channels/:CHANNEL_NAME/users
 ```
 
 ## Cross Domain Access To API
-Cross domain access can be specified in laravel-echo-server.json file by changing `allowCors` in `apiOriginAllow` to `true`. You can then set the CORS origin domain you want to allow, the http allow methods as a comma separated string (only GET works since it's read only data, at least as of right now) and the allow headers to allow to the API to receive.
+Cross domain access can be specified in laravel-echo-server.json file by changing `allowCors` in `apiOriginAllow` to `true`. You can then set the CORS origin domain you want to allow, the http allow methods as a comma separated string (only GET and POST works as of right now) and the allow headers to allow to the API to receive.
 
 Example below:
 
@@ -197,7 +197,7 @@ Example below:
   "apiOriginAllow":{
     "allowCors" : true,
     "allowOrigin" : "http://127.0.0.1",
-    "allowMethods" : "GET",
+    "allowMethods" : "GET, POST",
     "allowHeaders" : "Origin, Content-Type, X-Auth-Token, X-Requested-With, Accept, Authorization, X-CSRF-TOKEN, X-Socket-Id"
   }
 }

--- a/README.md
+++ b/README.md
@@ -186,6 +186,24 @@ List of users on a channel.
 GET /apps/:APP_ID/channels/:CHANNEL_NAME/users
 ```
 
+**Cross Domain Access To API**
+Cross domain access can be specified in laravel-echo-server.json file by changing `allowCors` in `apiOriginAllow` to `true`. You can then set the CORS origin domain you want to allow, the http allow methods as a comma separated string (only GET works since it's read only data, at least as of right now) and the allow headers to allow to the API to receive.
+
+Example below:
+
+``` json
+{
+  "apiOriginAllow":{
+    "allowCors" : true,
+    "allowOrigin" : "http://127.0.0.1",
+    "allowMethods" : "GET",
+    "allowHeaders" : "Origin, Content-Type, X-Auth-Token, X-Requested-With, Accept, Authorization, X-CSRF-TOKEN, X-Socket-Id"
+  }
+}
+
+```
+This allows you to ping the API via AJAX calls from your app that could be running on the same domain but different port or it could be entirely different domain.
+
 ## Database
 
 To persist presence channel data, there is support for use of Redis or SQLite as a key/value store. The key being the channel name, and the value being the list of presence channel members.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Edit the default configuration of the server by adding options to your **laravel
 | `sslCertChainPath` | `''`                 | The path to your server's ssl certificate chain |
 | `sslPassphrase`    | `''`                 | The pass phrase to use for the certificate (if applicable) |
 | `socketio`         | `{}`                 | Options to pass to the socket.io instance ([available options](https://github.com/socketio/engine.io#methods-1)) |
+| `apiOriginAllow`   | `{}`                 | Configuration to allow API be accessed over CORS. [Example](#cross-domain-access-to-api)|
 
 ### Running with SSL
 
@@ -186,7 +187,7 @@ List of users on a channel.
 GET /apps/:APP_ID/channels/:CHANNEL_NAME/users
 ```
 
-**Cross Domain Access To API**
+## Cross Domain Access To API
 Cross domain access can be specified in laravel-echo-server.json file by changing `allowCors` in `apiOriginAllow` to `true`. You can then set the CORS origin domain you want to allow, the http allow methods as a comma separated string (only GET works since it's read only data, at least as of right now) and the allow headers to allow to the API to receive.
 
 Example below:

--- a/src/api/http-api.ts
+++ b/src/api/http-api.ts
@@ -10,12 +10,21 @@ export class HttpApi {
      * @param  {any} channel
      * @param  {any} express
      */
-    constructor(private io, private channel, private express) { }
+    constructor(private io, private channel, private express, private options) { }
 
     /**
      * Initialize the API.
      */
     init(): void {
+        if(this.options.apiOriginAllow.allowCors){
+            this.express.use( (req, res, next) => {
+                res.header('Access-Control-Allow-Origin', this.options.apiOriginAllow.allowOrigin);
+                res.header('Access-Control-Allow-Methods', this.options.apiOriginAllow.allowMethods);
+                res.header('Access-Control-Allow-Headers', this.options.apiOriginAllow.allowHeaders);
+                next();
+            });
+        }
+
         this.express.get(
             '/apps/:appId/status',
             (req, res) => this.getStatus(req, res)

--- a/src/api/http-api.ts
+++ b/src/api/http-api.ts
@@ -9,6 +9,7 @@ export class HttpApi {
      * @param  {any} io
      * @param  {any} channel
      * @param  {any} express
+     * @param  {any} options object apiOriginAllow
      */
     constructor(private io, private channel, private express, private options) { }
 
@@ -16,11 +17,11 @@ export class HttpApi {
      * Initialize the API.
      */
     init(): void {
-        if(this.options.apiOriginAllow.allowCors){
+        if(this.options.allowCors){
             this.express.use( (req, res, next) => {
-                res.header('Access-Control-Allow-Origin', this.options.apiOriginAllow.allowOrigin);
-                res.header('Access-Control-Allow-Methods', this.options.apiOriginAllow.allowMethods);
-                res.header('Access-Control-Allow-Headers', this.options.apiOriginAllow.allowHeaders);
+                res.header('Access-Control-Allow-Origin', this.options.allowOrigin);
+                res.header('Access-Control-Allow-Methods', this.options.allowMethods);
+                res.header('Access-Control-Allow-Headers', this.options.allowHeaders);
                 next();
             });
         }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -115,7 +115,7 @@ export class Cli {
                 type: 'confirm'
             },{
                 name: 'allowOrigin',
-                default: 'http://localhost',
+                default: 'http://localhost:80',
                 message: 'Enter the domain you want CORS access to:',
                 when: function(options){
                     return options.corsAllow == true;

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -32,7 +32,7 @@ export class Cli {
     init(yargs) {
         this.setupConfig().then((options) => {
             options = Object.assign({}, this.defaultOptions, options);
-
+            
             if (options.addClient) {
                 let client = {
                     appId: this.createAppId(),
@@ -42,6 +42,13 @@ export class Cli {
 
                 console.log('appId: ' + colors.magenta(client.appId));
                 console.log('key: ' + colors.magenta(client.key));
+            }
+
+            if(options.corsAllow){
+                options.apiOriginAllow.allowCors = true;
+                options.apiOriginAllow.allowOrigin = options.allowOrigin;
+                options.apiOriginAllow.allowMethods = options.allowMethods;
+                options.apiOriginAllow.allowHeaders = options.allowHeaders;
             }
 
             this.saveConfig(options).then(() => {
@@ -101,6 +108,32 @@ export class Cli {
                 default: false,
                 message: 'Do you want to generate a client ID/Key for HTTP API?',
                 type: 'confirm'
+            }, {
+                name: 'corsAllow',
+                default: false,
+                message: 'Do you want to setup cross domain access to API? Useful for AJAX request to API on same domain different port.',
+                type: 'confirm'
+            },{
+                name: 'allowOrigin',
+                default: 'http://localhost',
+                message: 'Enter the domain you want CORS access to:',
+                when: function(options){
+                    return options.corsAllow == true;
+                }
+            },{
+                name: 'allowMethods',
+                default: 'GET, POST',
+                message: 'Enter the CORS HTTP methods you want to allow:',
+                when: function(options){
+                    return options.corsAllow == true;
+                }
+            },{
+                name: 'allowHeaders',
+                default: 'Origin, Content-Type, X-Auth-Token, X-Requested-With, Accept, Authorization, X-CSRF-TOKEN, X-Socket-Id',
+                message: 'Enter the CORS headers you want to allow:',
+                when: function(options){
+                    return options.corsAllow == true;
+                }
             }
         ]);
     }

--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -34,7 +34,13 @@ export class EchoServer {
         sslCertPath: '',
         sslKeyPath: '',
         sslCertChainPath: '',
-        sslPassphrase: ''
+        sslPassphrase: '',
+        apiOriginAllow:{
+            allowCors : false,
+            allowOrigin : '',
+            allowMethods : '',
+            allowHeaders : ''
+        }
     };
 
     /**
@@ -115,7 +121,7 @@ export class EchoServer {
             this.channel = new Channel(io, this.options);
             this.redisSub = new RedisSubscriber(this.options);
             this.httpSub = new HttpSubscriber(this.server.express, this.options);
-            this.httpApi = new HttpApi(io, this.channel, this.server.express);
+            this.httpApi = new HttpApi(io, this.channel, this.server.express, this.options);
             this.httpApi.init();
 
             this.onConnect();

--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -121,7 +121,7 @@ export class EchoServer {
             this.channel = new Channel(io, this.options);
             this.redisSub = new RedisSubscriber(this.options);
             this.httpSub = new HttpSubscriber(this.server.express, this.options);
-            this.httpApi = new HttpApi(io, this.channel, this.server.express, this.options);
+            this.httpApi = new HttpApi(io, this.channel, this.server.express, this.options.apiOriginAllow);
             this.httpApi.init();
 
             this.onConnect();


### PR DESCRIPTION
Added a fix to allow AJAX calls to ping the API from either same domain different port, or totally different domain. CORS settings are set from laravel-echo-server.json file. Ran into a situation where I needed this and fixed it manually but that's not a long term fix, so I decided to make a fork and pull request with this feature.

Thank you for looking into and hopefully integrating it with the system. 

Thanks!