### PR TITLE
allowing multiple nodes using socket.io-redis

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lodash": "^4.12.0",
     "request": "^2.72.0",
     "socket.io": "^2.0.1",
+    "socket.io-redis": "^5.2.0",
     "sqlite3": "^3.1.8",
     "yargs": "^5.0.0"
   },

--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -192,7 +192,7 @@ export class EchoServer {
      * @return {boolean}
      */
     toOthers(socket: any, channel: string, message: any): boolean {
-        socket.broadcast.to(channel)
+        socket.broadcast.to(channel).local
             .emit(message.event, channel, message.data);
 
         return true
@@ -207,7 +207,7 @@ export class EchoServer {
      * @return {boolean}
      */
     toAll(channel: string, message: any): boolean {
-        this.server.io.to(channel)
+        this.server.io.to(channel).local
             .emit(message.event, channel, message.data);
 
         return true

--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -192,6 +192,9 @@ export class EchoServer {
      * @return {boolean}
      */
     toOthers(socket: any, channel: string, message: any): boolean {
+
+        socket.flags['local'] = true;
+
         socket.broadcast.to(channel).local
             .emit(message.event, channel, message.data);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,8 @@ var https = require('https');
 var express = require('express');
 var url = require('url');
 var io = require('socket.io');
+var Redis = require('ioredis');
+var adapter = require('socket.io-redis');
 import { Log } from './log';
 
 export class Server {
@@ -36,6 +38,14 @@ export class Server {
             this.serverProtocol().then(() => {
                 let host = this.options.host || 'localhost';
                 Log.success(`Running at ${host} on port ${this.options.port}`);
+
+                if(this.options.database == "redis")
+                {
+                  var pubClient = new Redis(this.options.databaseConfig.redis);
+                  var subClient = new Redis(this.options.databaseConfig.redis);
+
+                  this.io.adapter(adapter({ key:'adapter', pubClient: pubClient , subClient: subClient }));
+                }
 
                 resolve(this.io);
             }, error => reject(error));

--- a/src/subscribers/redis-subscriber.ts
+++ b/src/subscribers/redis-subscriber.ts
@@ -28,6 +28,12 @@ export class RedisSubscriber implements Subscriber {
 
         return new Promise((resolve, reject) => {
             this._redis.on('pmessage', (subscribed, channel, message) => {
+
+                // Ingore socket.io-redis adapter messages.
+                if (channel.startsWith("adapter")) {
+                  return;
+                }
+
                 try {
                     message = JSON.parse(message);
 


### PR DESCRIPTION
At the moment laravel-echo-server can run in single instance mode because it 's using the default in-memory adapter which means whispers won't be propagated across nodes.

Here are the changes that make it possible to run multiple nodes.

- Added socket.io-redis as an adapter when redis db is set
- Modified the redis-subscriber to ignore all messages coming from the adapter
- Modified the echo-server to broadcasts to local connections only to avoid sending multiple events due to the new adapter behavior.