### PR TITLE
Allow loading of default Laravel .env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Laravel Echo Server
+# Laravel Echo Server
 
 NodeJs server for Laravel Echo broadcasting with Socket.io.
 
@@ -76,6 +76,7 @@ Edit the default configuration of the server by adding options to your **laravel
 | `authHost`         | `http://localhost`   | The host of the server that authenticates private and presence channels  |
 | `database`         | `redis`              | Database used to store data that should persist, like presence channel members. Options are currently `redis` and `sqlite` |
 | `databaseConfig`   |  `{}`                | Configurations for the different database drivers [Example](#database)|
+| `envFilePath`      |  `false`             | Path to your Laravel `.env` file. The `authHost`, `host` and `devMode` options will be dynamically loaded from here.|
 | `host`             | `null`               | The host of the socket.io server ex.`app.dev`. `null` will accept connections on any IP-address |
 | `port`             | `6001`               | The port that the socket.io server should run on |
 | `protocol`         | `http`               | either `http` or `https` |

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "colors": "^1.1.2",
+    "dotenv": "^5.0.1",
     "express": "^4.14.0",
     "inquirer": "^1.1.3",
     "ioredis": "^1.15.1",


### PR DESCRIPTION
This seeks to address the issue that was raised in https://github.com/tlaverdure/laravel-echo-server/issues/178.
It's a problem I was having tonight when trying to deploy a project using `laravel-echo-server` to a staging environment and off of my local for the first time.

In the solution below I decided to take the middle path between simple and configurable allowing for a bit of configuration without too much overhead.

Should you believe that this is a good approach, any suggestions or requests to adapt the code are welcome.