### PR TITLE
Send leave notice to application server when users unsubscribe presence channels or disconnecting

### DIFF
--- a/src/channels/presence-channel.ts
+++ b/src/channels/presence-channel.ts
@@ -115,7 +115,7 @@ export class PresenceChannel {
     }
 
     /**
-     * Remove a member from a presenece channel and broadcast they have left
+     * Remove a member from a presence channel and broadcast they have left
      * only if not other presence channel instances exist.
      *
      * @param  {any} socket
@@ -136,6 +136,22 @@ export class PresenceChannel {
                     this.onLeave(channel, member);
                 }
             });
+        }, error => Log.error(error));
+    }
+
+    /**
+     * Get a member from a presence channel.
+     *
+     * @param  {any} socket
+     * @param  {string} channel
+     * @return {Promise}
+     */
+    getMember(socket: any, channel: string): Promise<any> {
+        return this.getMembers(channel).then(members => {
+            members = members || [];
+            let member = members.find(member => member.socketId == socket.id);
+
+            return member;
         }, error => Log.error(error));
     }
 

--- a/src/channels/private-channel.ts
+++ b/src/channels/private-channel.ts
@@ -39,6 +39,30 @@ export class PrivateChannel {
     }
 
     /**
+     * Send leave notice to application server.
+     *
+     * @param  {any} socket
+     * @param  {any} member
+     * @param  {array} channels
+     * @return {void}
+     */
+    leaveNotice(socket: any, member: any, channels: Array<string>) : void {
+        let client = this.options.clients[0];
+
+        let options = {
+            url: this.authHost(socket) + this.options.leaveEndpoint,
+            form: { member: member, channel_names: channels },
+            auth: { username: client.appId, password: client.key }
+        };
+
+        this.request.post(options, (error, response) => {
+            if (error || response.statusCode !== 200) {
+                Log.error(error || response.body);
+            }
+        });
+    }
+
+    /**
      * Get the auth host based on the Socket.
      *
      * @param {any} socket

--- a/src/channels/private-channel.ts
+++ b/src/channels/private-channel.ts
@@ -47,6 +47,9 @@ export class PrivateChannel {
      * @return {void}
      */
     leaveNotice(socket: any, member: any, channels: Array<string>) : void {
+        member.socket_id = member.socketId;
+        delete member.socketId;
+
         let client = this.options.clients[0];
 
         let options = {

--- a/src/channels/private-channel.ts
+++ b/src/channels/private-channel.ts
@@ -30,7 +30,7 @@ export class PrivateChannel {
     authenticate(socket: any, data: any): Promise<any> {
         let options = {
             url: this.authHost(socket) + this.options.authEndpoint,
-            form: { channel_name: data.channel },
+            form: { channel_name: data.channel, socket_id: socket.id },
             headers: (data.auth && data.auth.headers) ? data.auth.headers : {},
             rejectUnauthorized: false
         };

--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -18,6 +18,7 @@ export class EchoServer {
     public defaultOptions: any = {
         authHost: 'http://localhost',
         authEndpoint: '/broadcasting/auth',
+        leaveEndpoint: '/broadcasting/leave',
         clients: [],
         database: 'redis',
         databaseConfig: {
@@ -253,7 +254,7 @@ export class EchoServer {
      */
     onUnsubscribe(socket: any): void {
         socket.on('unsubscribe', data => {
-            this.channel.leave(socket, data.channel, 'unsubscribed');
+            this.channel.leave(socket, 'unsubscribed', data.channel);
         });
     }
 
@@ -264,11 +265,7 @@ export class EchoServer {
      */
     onDisconnecting(socket: any): void {
         socket.on('disconnecting', (reason) => {
-            Object.keys(socket.rooms).forEach(room => {
-                if (room !== socket.id) {
-                    this.channel.leave(socket, room, reason);
-                }
-            });
+            this.channel.leave(socket, reason);
         });
     }
 


### PR DESCRIPTION
Add a event feedback mechanism about making a event notice to callback the HTTP API when users unsubscribe the presence channel or disconnect sockets.
It looks like a logout request, as same as the authenticate request which is from echo-server to app server. But it is based on http basic auth and it is only for presence channel.
It provides a better way to handle the problem mentioned at #257 . And you can disable it through setting `leaveEndpoint` as empty string in laravel-echo-server.json.

# How to use
## For laravel-echo-server
Edit laravel-echo-server.json, add some keys, as below
``` json
    "leaveEndpoint": "/broadcasting/leave",
    "clients": [
        {"appId": "123", "key": "123456"}
    ],
```
It uses the value of `clients[0]` as the basic auth user.

## For laravel
``` php
Route::post('broadcasting/leave', function (\Illuminate\Http\Request $request) {
    // basic auth
    if ($request->getUser() != '123' || $request->getPassword() != '123456') {
        return response('Unauthorized', 401, [
            'WWW-Authenticate' => 'Basic realm="myRealm"'
        ]);
    }

    // some logic
    $data = $request->all();
    logger(var_export($data, true));
});
```
The `$data` structure: 
``` php
$data = [
    'member' => [
        'user_id' => '1',
        'user_info' => ['id' => '1'],
        'socket_id' => 'KUTaO6IIIJoKVznHAAAB'
    ],
    'channel_names' => [
        'presence-App.Group.1',
        'presence-App.Group.2'
    ]
]
```

