### PR TITLE
Add simple index route for HTTP API.

### DIFF
--- a/src/api/http-api.ts
+++ b/src/api/http-api.ts
@@ -20,6 +20,11 @@ export class HttpApi {
         this.corsMiddleware();
 
         this.express.get(
+            '/',
+            (req, res) => this.getRoot(req, res),
+        );
+
+        this.express.get(
             '/apps/:appId/status',
             (req, res) => this.getStatus(req, res)
         );
@@ -52,6 +57,16 @@ export class HttpApi {
                 next();
             });
         }
+    }
+
+    /**
+     * Outputs a simple message to show that the server is running.
+     *
+     * @param {any} req
+     * @param {any} res
+     */
+    getRoot(req: any, res: any): void {
+        res.send('OK');
     }
 
     /**


### PR DESCRIPTION
This adds a simple route to the HTTP API.

`GET /` now returns an 'OK' message with a 200 response code (or 304).

This is so a client-side library can check that the echo server is running before attempting to connect.

Currently the only option is to wait for a WebSocket to fail if the server is not running, or try and make an HTTP request against one of the existing URLs, which will only return a successful response code if you supply the correct [client credentials](https://github.com/tlaverdure/laravel-echo-server#api-clients). We don't want to do that because then the other HTTP endpoints would be available to reveal information about the server.

Adding the simple `/` route allows an HTTP request that will return a HTTP 200.