### PR TITLE
fix broadcasting of presence channel events

### DIFF
--- a/src/channels/presence-channel.ts
+++ b/src/channels/presence-channel.ts
@@ -105,7 +105,7 @@ export class PresenceChannel {
 
                 this.onSubscribed(socket, channel, members);
 
-                if (!is_member) {
+                if (is_member) {
                     this.onJoin(socket, channel, member);
                 }
             }, error => Log.error(error));
@@ -131,7 +131,7 @@ export class PresenceChannel {
             this.db.set(channel + ':members', members);
 
             this.isMember(channel, member).then(is_member => {
-                if (!is_member) {
+                if (is_member) {
                     delete member.socketId;
                     this.onLeave(channel, member);
                 }


### PR DESCRIPTION
I'm using PresenceChannels with LES, and I'm listening for users joining/leaving using ``Echo.join('...').joining()`` and  ``.leaving()``. From my testing, users joining or leaving is only broadcasted from LES very rarely.

It appears that this can be fixed by the changes proposed here.

I have to admit though that I don't really understand what's happening in this couple of lines, so these changes might actually break something that I'm not aware of.