### PR TITLE
If cookie are sent within the message, use them.

### DIFF
--- a/src/channels/private-channel.ts
+++ b/src/channels/private-channel.ts
@@ -59,7 +59,7 @@ export class PrivateChannel {
 
 			for (let authHost of authHosts) {
 				authHostSelected = authHost;
-	
+
 				if (this.hasMatchingHost(referer, authHost)) {
 					authHostSelected = `${referer.protocol}//${referer.host}`;
 					break;
@@ -136,7 +136,7 @@ export class PrivateChannel {
      * @return {any}
      */
     protected prepareHeaders(socket: any, options: any): any {
-        options.headers['Cookie'] = socket.request.headers.cookie;
+        options.headers['Cookie'] = options.headers['Cookie'] || socket.request.headers.cookie;
         options.headers['X-Requested-With'] = 'XMLHttpRequest';
 
         return options.headers;


### PR DESCRIPTION
Since cookies are always retrieved from the first request payload,
it's really hard to handle authentication on the client side.

One example, if the socket connexion is opened before the user is logged,
the socket will never be able to know about the logged state.

By using the options.headers['Cookie'] value as default (if set) we let
the user bypass cookies and handle the full state from the client side.

Maybe there is a useful reason to always use the first cookie sent, if so, please tell me about it 😄.