### PR TITLE
Updated port value to address issue with OpenShift

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -35,14 +35,22 @@ export class Server {
         return new Promise((resolve, reject) => {
             this.serverProtocol().then(() => {
                 let host = this.options.host || 'localhost';
-                let portRegex = /([0-9]{2,5})[\/]?$/;
-                let portToUse = this.options.port.match(portRegex); //idex 1 contains the cleaned port number only
-                portToUse = portToUse[1];
-                Log.success(`Running at ${host} on port ${portToUse}`);
+                Log.success(`Running at ${host} on port ${this.getPort()}`);
 
                 resolve(this.io);
             }, error => reject(error));
         });
+    }
+    
+    /**
+    * Sanitize the port number from any extra characters
+    *
+    * @return {any}
+    */
+    getPort() {
+        let portRegex = /([0-9]{2,5})[\/]?$/;
+        let portToUse = this.options.port.match(portRegex); //idex 1 contains the cleaned port number only
+        return portToUse[1];
     }
 
     /**
@@ -97,11 +105,8 @@ export class Server {
         } else {
             var httpServer = http.createServer(this.express);
         }
-        var portRegex = /([0-9]{2,5})[\/]?$/;
-        var portToUse = this.options.port.match(portRegex); //idex 1 contains the cleaned port number only
-        portToUse = portToUse[1];
-
-        httpServer.listen(portToUse, this.options.host);
+      
+        httpServer.listen(this.getPort(), this.options.host);
 
         this.authorizeRequests();
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,7 +35,10 @@ export class Server {
         return new Promise((resolve, reject) => {
             this.serverProtocol().then(() => {
                 let host = this.options.host || 'localhost';
-                Log.success(`Running at ${host} on port ${this.options.port}`);
+                let portRegex = /([0-9]{2,5})[\/]?$/;
+                let portToUse = this.options.port.match(portRegex); //idex 1 contains the cleaned port number only
+                portToUse = portToUse[1];
+                Log.success(`Running at ${host} on port ${portToUse}`);
 
                 resolve(this.io);
             }, error => reject(error));
@@ -94,8 +97,11 @@ export class Server {
         } else {
             var httpServer = http.createServer(this.express);
         }
+        var portRegex = /([0-9]{2,5})[\/]?$/;
+        var portToUse = this.options.port.match(portRegex); //idex 1 contains the cleaned port number only
+        portToUse = portToUse[1];
 
-        httpServer.listen(this.options.port, this.options.host);
+        httpServer.listen(portToUse, this.options.host);
 
         this.authorizeRequests();
 


### PR DESCRIPTION
Encountered an issue specifically in OpenShift where the port number that is read from the "options" is returned as "tcp://x.x.x.x:6001" instead of just "6001". This does not happen in Docker, only OpenShift. 
I added a RegEx to parse the actual port number out of the "this.options.port". For most users, this will have no effect as it will still return the port number. But if a full tcp string is given, it will grab just the port number and bind to it. This was causing issues when attempting to .listen().
