### PR TITLE
Add missing documentation for some options to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,31 +72,30 @@ Edit the default configuration of the server by adding options to your **laravel
 
 | Title              | Default              | Description                 |
 | :------------------| :------------------- | :---------------------------|
+| `apiOriginAllow`   | `{}`                 | Configuration to allow API be accessed over CORS. [Example](#cross-domain-access-to-api) |
 | `authEndpoint`     | `/broadcasting/auth` | The route that authenticates private channels  |
 | `authHost`         | `http://localhost`   | The host of the server that authenticates private and presence channels  |
 | `database`         | `redis`              | Database used to store data that should persist, like presence channel members. Options are currently `redis` and `sqlite` |
 | `databaseConfig`   |  `{}`                | Configurations for the different database drivers [Example](#database) |
+| `devMode`          | `false`              | Adds additional logging for development purposes |
 | `host`             | `null`               | The host of the socket.io server ex.`app.dev`. `null` will accept connections on any IP-address |
 | `port`             | `6001`               | The port that the socket.io server should run on |
-| `protocol`         | `http`               | either `http` or `https` |
+| `protocol`         | `http`               | Must be either `http` or `https` |
 | `sslCertPath`      | `''`                 | The path to your server's ssl certificate |
 | `sslKeyPath`       | `''`                 | The path to your server's ssl key |
 | `sslCertChainPath` | `''`                 | The path to your server's ssl certificate chain |
 | `sslPassphrase`    | `''`                 | The pass phrase to use for the certificate (if applicable) |
 | `socketio`         | `{}`                 | Options to pass to the socket.io instance ([available options](https://github.com/socketio/engine.io#methods-1)) |
-| `apiOriginAllow`   | `{}`                 | Configuration to allow API be accessed over CORS. [Example](#cross-domain-access-to-api) |
+| `subscribers`      | `{"http": true, "redis": true}` | Allows to disable subscribers individually. Available subscribers: `http` and `redis` |
 
 ### DotEnv
 If a .env file is found in the same directory as the laravel-echo-server.json
 file, the following options can be overridden:
 
--   Auth Host: `LARAVEL_ECHO_SERVER_AUTH_HOST` *Note*: This option will fall back to the `LARAVEL_ECHO_SERVER_HOST` option as the default if that is set in the .env file.
-
--   *Host*: `LARAVEL_ECHO_SERVER_HOST`
-
--   *Port*: `LARAVEL_ECHO_SERVER_PORT`
-
--   *Debug*: `LARAVEL_ECHO_SERVER_DEBUG`
+- `authHost`: `LARAVEL_ECHO_SERVER_AUTH_HOST` *Note*: This option will fall back to the `LARAVEL_ECHO_SERVER_HOST` option as the default if that is set in the .env file.
+- `host`: `LARAVEL_ECHO_SERVER_HOST`
+- `port`: `LARAVEL_ECHO_SERVER_PORT`
+- `devMode`: `LARAVEL_ECHO_SERVER_DEBUG`
 
 
 ### Running with SSL


### PR DESCRIPTION
The new `subscribers` option added in #333 as well as the old `devMode` option were missing from the documentation. This PR also reworks the environment variable documentation slightly, so that it is clear what is meant.

I also moved one option to sort the configuration options alphabetically.