### PR TITLE
By default insecure TLS v1 is now disabled

### DIFF
--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -5,6 +5,7 @@ import { HttpApi } from './api';
 import { Log } from './log';
 import * as fs from 'fs';
 const packageFile = require('../package.json');
+const { constants } = require('crypto');
 
 /**
  * Echo server class.
@@ -31,6 +32,7 @@ export class EchoServer {
         port: 6001,
         protocol: "http",
         socketio: {},
+        secureOptions: constants.SSL_OP_NO_TLSv1,
         sslCertPath: '',
         sslKeyPath: '',
         sslCertChainPath: '',


### PR DESCRIPTION
This disables TLS 1.0 to be disabled by default. To allow TLS 1.0, you can override this option with an empty string.