### PR TITLE
Add redis password to allowed env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ file, the following options can be overridden:
 - `devMode`: `LARAVEL_ECHO_SERVER_DEBUG`
 - `databaseConfig.redis.host`: `LARAVEL_ECHO_SERVER_REDIS_HOST`
 - `databaseConfig.redis.port`: `LARAVEL_ECHO_SERVER_REDIS_PORT`
+- `databaseConfig.redis.password`: `LARAVEL_ECHO_SERVER_REDIS_PASSWORD`
 
 
 ### Running with SSL

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -33,6 +33,7 @@ export class Cli {
         'LARAVEL_ECHO_SERVER_PORT': 'port',
         'LARAVEL_ECHO_SERVER_REDIS_HOST': 'databaseConfig.redis.host',
         'LARAVEL_ECHO_SERVER_REDIS_PORT': 'databaseConfig.redis.port',
+        'LARAVEL_ECHO_SERVER_REDIS_PASSWORD': 'databaseConfig.redis.password',
     };
 
     /**


### PR DESCRIPTION
It's a good practice to use password for redis connections and most of the projects already handle all the things in different environments in env file. So it would be handy to be able to set password in .env