### PR TITLE
Parse json string to a function for socketio parameter.

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -469,7 +469,13 @@ export class Cli {
         let data = {};
 
         try {
-            data = JSON.parse(fs.readFileSync(file, 'utf8'));
+            data = JSON.parse(fs.readFileSync(file, 'utf8'), function (key, value) {
+             if (key == "allowRequest") {
+                 return new Function("return " + value)();;
+             } else {
+               return value;
+             }
+         });
         } catch {
             console.error(colors.error('Error: There was a problem reading the config file.'));
             process.exit();


### PR DESCRIPTION
Hi,
This is our first PR ever.

We are testing `allowRequest` socketio option.
What we are trying to acomplish is to authorize first GET handshake, and allowRequest method looks like it is meant for that.

When parsing `laravel-echo-server.json` function is parsed as string and leads to an error once a websocket connection is started.

> TypeError: this.allowRequest is not a function

The cleanest solution we could think of is this https://stackoverflow.com/a/28011280/2908113

Hope this PR is clear enough, and is properly formated.