### PR TITLE
#400 KeyPrefix for redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ For example, if you wanted to pass a custom configuration to Redis:
     "redis" : {
       "port": "3001",
       "host": "redis.app.dev"
+      "keyPrefix": "my-redis-prefix"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ For example, if you wanted to pass a custom configuration to Redis:
   "databaseConfig" : {
     "redis" : {
       "port": "3001",
-      "host": "redis.app.dev"
+      "host": "redis.app.dev",
       "keyPrefix": "my-redis-prefix"
     }
   }

--- a/src/subscribers/redis-subscriber.ts
+++ b/src/subscribers/redis-subscriber.ts
@@ -45,7 +45,7 @@ export class RedisSubscriber implements Subscriber {
                         Log.info("Event: " + message.event);
                     }
 
-                    callback(channel, message);
+                    callback(channel.substring(0, this.keyPrefix.length), message);
                 } catch (e) {
                     if (this.options.devMode) {
                         Log.info("No JSON message");

--- a/src/subscribers/redis-subscriber.ts
+++ b/src/subscribers/redis-subscriber.ts
@@ -45,7 +45,7 @@ export class RedisSubscriber implements Subscriber {
                         Log.info("Event: " + message.event);
                     }
 
-                    callback(channel.substring(0, this.keyPrefix.length), message);
+                    callback(channel.substring(this.keyPrefix.length), message);
                 } catch (e) {
                     if (this.options.devMode) {
                         Log.info("No JSON message");

--- a/src/subscribers/redis-subscriber.ts
+++ b/src/subscribers/redis-subscriber.ts
@@ -11,11 +11,20 @@ export class RedisSubscriber implements Subscriber {
     private _redis: any;
 
     /**
+     *
+     * KeyPrefix for used in the redis Connection
+     *
+     * @type {String}
+     */
+    private keyPrefix: string;
+
+    /**
      * Create a new instance of subscriber.
      *
      * @param {any} options
      */
     constructor(private options) {
+	this._keyPrefix = options.databaseConfig.redis.keyPrefix || '';
         this._redis = new Redis(options.databaseConfig.redis);
     }
 
@@ -44,7 +53,7 @@ export class RedisSubscriber implements Subscriber {
                 }
             });
 
-            this._redis.psubscribe('*', (err, count) => {
+            this._redis.psubscribe(`${this.keyPrefix}*`, (err, count) => {
                 if (err) {
                     reject('Redis could not subscribe.')
                 }

--- a/src/subscribers/redis-subscriber.ts
+++ b/src/subscribers/redis-subscriber.ts
@@ -24,7 +24,7 @@ export class RedisSubscriber implements Subscriber {
      * @param {any} options
      */
     constructor(private options) {
-	this._keyPrefix = options.databaseConfig.redis.keyPrefix || '';
+        this._keyPrefix = options.databaseConfig.redis.keyPrefix || '';
         this._redis = new Redis(options.databaseConfig.redis);
     }
 

--- a/src/subscribers/redis-subscriber.ts
+++ b/src/subscribers/redis-subscriber.ts
@@ -16,7 +16,7 @@ export class RedisSubscriber implements Subscriber {
      *
      * @type {String}
      */
-    private keyPrefix: string;
+    private _keyPrefix: string;
 
     /**
      * Create a new instance of subscriber.
@@ -45,7 +45,7 @@ export class RedisSubscriber implements Subscriber {
                         Log.info("Event: " + message.event);
                     }
 
-                    callback(channel.substring(this.keyPrefix.length), message);
+                    callback(channel.substring(this._keyPrefix.length), message);
                 } catch (e) {
                     if (this.options.devMode) {
                         Log.info("No JSON message");
@@ -53,7 +53,7 @@ export class RedisSubscriber implements Subscriber {
                 }
             });
 
-            this._redis.psubscribe(`${this.keyPrefix}*`, (err, count) => {
+            this._redis.psubscribe(`${this._keyPrefix}*`, (err, count) => {
                 if (err) {
                     reject('Redis could not subscribe.')
                 }


### PR DESCRIPTION
We need to use a prefix in our laravel redis connection and therefore the laravel-echo-server needs to acknowledge this prefix as well.
I used the same option referenced in [this comment](https://github.com/tlaverdure/laravel-echo-server/pull/438#issuecomment-554062994)