### PR TITLE
added: method to determine the authEndpoint

### DIFF
--- a/src/channels/private-channel.ts
+++ b/src/channels/private-channel.ts
@@ -21,7 +21,7 @@ export class PrivateChannel {
      */
     authenticate(socket: any, data: any): Promise<any> {
         let options = {
-            url: this.authHost(socket) + this.options.authEndpoint,
+            url: this.authHost(socket) + this.authEndpoint(data),
             form: { channel_name: data.channel },
             headers: (data.auth && data.auth.headers) ? data.auth.headers : {},
             rejectUnauthorized: false
@@ -65,6 +65,19 @@ export class PrivateChannel {
         }
 
         return authHostSelected;
+    }
+
+    /**
+     * Prefer the auth endpoint given by the client, fallback to the default options
+     */
+    protected authEndpoint(data: any) {
+        let authEndpoint = data.authEndpoint || this.options.authEndpoint;
+
+        if (this.options.devMode) {
+            Log.info(`[${new Date().toLocaleTimeString()}] - Using authentication endpoint: ${authEndpoint}`);
+        }
+
+        return authEndpoint
     }
 
     /**

--- a/src/channels/private-channel.ts
+++ b/src/channels/private-channel.ts
@@ -71,7 +71,7 @@ export class PrivateChannel {
      * Prefer the auth endpoint given by the client, fallback to the default options
      */
     protected authEndpoint(data: any) {
-        let authEndpoint = data.authEndpoint || this.options.authEndpoint;
+        let authEndpoint = (data.auth && data.auth.endpoint) ? data.auth.endpoint : this.options.authEndpoint;
 
         if (this.options.devMode) {
             Log.info(`[${new Date().toLocaleTimeString()}] - Using authentication endpoint: ${authEndpoint}`);


### PR DESCRIPTION
Within Laravel you can alter the broadcast auth route. 
```php
Broadcast::routes(['middleware' => ['api', 'jwt.auth']]);
// Or
Broadcast::routes(['prefix' => 'api', 'middleware' => ['api', 'jwt.auth']]);
```
Of course this is no problem when you run _one_ echo-server and _one_ laravel app. Then you alter the config accordingly in the echo-server. Most likely u keep using the `web` middleware with CsrfToken validation (by default).

## But
When you have one laravel backend with multiple apps (clients), who have to connect to the same backend and these clients use different strategies to authenticate.

Use case:
Client1
 - is an laravel app served from same host as the backend api
 - uses CSRF token protection
 - has an session.
 - pages are served from the server 

Client2 
 - is an standalone SPA 
 - uses some sort of JWT token via oauth.
 - has no Session (stateless)
 - only communicates through the Api with an token in every request.


To let both clients authenticate, we have to use multiple types of auth routes. with different middlewares to validate the user.
```php
// For Client 1
Broadcast::routes(['middleware' => ['web']]);    // result: `/broadcasting/auth` with CsrfToken
// And for Client 2
Broadcast::routes(['prefix' => 'api', 'middleware' => ['api', 'jwt.auth']]); // result: `/api/broadcasting/auth` stateless user via jwt validation
```

In case of Private or Presence channels, the echo server must authenticate against the authHost + AuthEndpoint. 

> Wouldn't it be wonderful if the Client can also decide to which endpoint they validate.

To solve this we can pass an extra option to the echo-server when the client connects.

```javascript
import Echo from 'laravel-echo'
import Io from 'socket.io-client'

const EchoInstance = new Echo({
  client: Io,
  broadcaster: 'socket.io',
  host: 'http://echo.domain.com',
  auth: {
    endpoint: '/api/broadcasting/auth'
  }
})
```

