### PR TITLE
Add method to stop the running server

### DIFF
--- a/examples/server_stop.js
+++ b/examples/server_stop.js
@@ -1,0 +1,7 @@
+var echo = require('../dist/index.js');
+
+var options = require('../laravel-echo-server');
+
+echo.run(options).then(echo => {
+    echo.stop();
+});

--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -141,6 +141,7 @@ export class EchoServer {
         });
         promises.push(this.server.io.close());
         return Promise.all(promises).then(() => {
+            this.subscribers = [];
             console.log('The LARAVEL ECHO SERVER server has been stopped.');
         });
     }

--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -131,6 +131,21 @@ export class EchoServer {
     }
 
     /**
+     * Stop the echo server.
+     */
+    stop(): Promise<any> {
+        console.log('Stopping the LARAVEL ECHO SERVER')
+        let promises = [];
+        this.subscribers.forEach(subscriber => {
+            promises.push(subscriber.unsubscribe());
+        });
+        promises.push(this.server.io.close());
+        return Promise.all(promises).then(() => {
+            console.log('The LARAVEL ECHO SERVER server has been stopped.');
+        });
+    }
+
+    /**
      * Listen for incoming event from subscibers.
      */
     listen(): Promise<any> {

--- a/src/subscribers/http-subscriber.ts
+++ b/src/subscribers/http-subscriber.ts
@@ -37,6 +37,24 @@ export class HttpSubscriber implements Subscriber {
     }
 
     /**
+     * Unsubscribe from events to broadcast.
+     *
+     * @return {Promise}
+     */
+    unsubscribe(): Promise<any> {
+        return new Promise((resolve, reject) => {
+            try {
+                this.express.post('/apps/:appId/events', (req, res) => {
+                    res.status(404).send();
+                });
+                resolve();
+            } catch(e) {
+                reject('Could not overwrite the event endpoint -> ' + e);
+            }
+        });
+    }
+
+    /**
      * Handle incoming event data.
      *
      * @param  {any} req

--- a/src/subscribers/redis-subscriber.ts
+++ b/src/subscribers/redis-subscriber.ts
@@ -64,4 +64,20 @@ export class RedisSubscriber implements Subscriber {
             });
         });
     }
+
+    /**
+     * Unsubscribe from events to broadcast.
+     *
+     * @return {Promise}
+     */
+    unsubscribe(): Promise<any> {
+        return new Promise((resolve, reject) => {
+            try {
+                this._redis.disconnect();
+                resolve();
+            } catch(e) {
+                reject('Could not disconnect from redis -> ' + e);
+            }
+        });
+    }
 }

--- a/src/subscribers/subscriber.ts
+++ b/src/subscribers/subscriber.ts
@@ -6,4 +6,11 @@ export interface Subscriber {
      * @return {void}
      */
     subscribe(callback: Function): Promise<any>;
+
+    /**
+     * Unsubscribe from incoming events
+     *
+     * @return {Promise}
+     */
+    unsubscribe(): Promise<any>;
 }


### PR DESCRIPTION
Added a method to stop the running echo server.

When the server is stopped Redis subscriber is disconnected, the http-subscriber endpoint is changed to 404 and the socket.io server is closed.