### PR TITLE
Fix crash when invalid referer is sent

### DIFF
--- a/src/channels/private-channel.ts
+++ b/src/channels/private-channel.ts
@@ -71,7 +71,7 @@ export class PrivateChannel {
      * Check if there is a matching auth host.
      */
     protected hasMatchingHost(referer: any, host: any): boolean {
-        return referer.hostname.substr(referer.hostname.indexOf('.')) === host ||
+        return (referer.hostname && referer.hostname.substr(referer.hostname.indexOf('.')) === host) ||
             `${referer.protocol}//${referer.host}` === host ||
             referer.host === host;
     }


### PR DESCRIPTION
In my production environment the echo server crashed regularly with the following exception:

```
[3:59:41 PM] - bQMwq6OeDT4g3BddAAau joined channel: footer-stats
/usr/lib/node_modules/laravel-echo-server/dist/channels/private-channel.js:48
        return referer.hostname.substr(referer.hostname.indexOf('.')) === host ||
                                ^

TypeError: Cannot read property 'substr' of null
    at PrivateChannel.hasMatchingHost (/usr/lib/node_modules/laravel-echo-server/dist/channels/private-channel.js:48:33)
    at PrivateChannel.authHost (/usr/lib/node_modules/laravel-echo-server/dist/channels/private-channel.js:35:26)
    at PrivateChannel.authenticate (/usr/lib/node_modules/laravel-echo-server/dist/channels/private-channel.js:13:23)
    at Channel.joinPrivate (/usr/lib/node_modules/laravel-echo-server/dist/channels/channel.js:68:22)
    at Channel.join (/usr/lib/node_modules/laravel-echo-server/dist/channels/channel.js:21:22)
    at Socket.<anonymous> (/usr/lib/node_modules/laravel-echo-server/dist/echo-server.js:128:27)
    at Socket.emit (events.js:310:20)
    at /usr/lib/node_modules/laravel-echo-server/node_modules/socket.io/lib/socket.js:528:12
    at processTicksAndRejections (internal/process/task_queues.js:79:11)
```

It seems some clients somehow send an invalid `Referer` header. This fix prevents the crash of echo server.