### PR TITLE
Fixes Cannot read property 'socketId' of undefined

### DIFF
--- a/src/channels/presence-channel.ts
+++ b/src/channels/presence-channel.ts
@@ -119,19 +119,28 @@ export class PresenceChannel {
         this.getMembers(channel).then(
             (members) => {
                 members = members || [];
-                let member = members.find(
-                    (member) => member.socketId == socket.id
-                );
-                members = members.filter((m) => m.socketId != member.socketId);
+
+                let member
+
+                members = members.filter((m) => {
+                    if(m.socketId == socket.id) {
+                        member = m
+                        return false
+                    }
+
+                    return true
+                });
 
                 this.db.set(channel + ":members", members);
 
-                this.isMember(channel, member).then((is_member) => {
-                    if (!is_member) {
-                        delete member.socketId;
-                        this.onLeave(channel, member);
-                    }
-                });
+                if(member) {
+                    this.isMember(channel, member).then((is_member) => {
+                        if (!is_member) {
+                            delete member.socketId;
+                            this.onLeave(channel, member);
+                        }
+                    });
+                }
             },
             (error) => Log.error(error)
         );


### PR DESCRIPTION
This PR adds check for member and reduce loops find + filter => only filter

On highload projects sometimes I catch:
```
(node:5114) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'socketId' of undefined
    at /usr/lib64/node_modules/laravel-echo-server/dist/channels/presence-channel.js:74:81
    at Array.filter (<anonymous>)
    at /usr/lib64/node_modules/laravel-echo-server/dist/channels/presence-channel.js:74:31
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
``` 

a member is not present on a channel.

