### PR TITLE
Add the user-agent and the remote address ip

### DIFF
--- a/src/channels/private-channel.ts
+++ b/src/channels/private-channel.ts
@@ -122,6 +122,8 @@ export class PrivateChannel {
     protected prepareHeaders(socket: any, options: any): any {
         options.headers['Cookie'] = options.headers['Cookie'] || socket.request.headers.cookie;
         options.headers['X-Requested-With'] = 'XMLHttpRequest';
+        options.headers["User-Agent"] = socket.request.headers["user-agent"];
+        options.headers["X-Forwarded-For"] = socket.request.headers["x-forwarded-for"] || socket.conn.remoteAddress;
 
         return options.headers;
     }


### PR DESCRIPTION
When using the Private channel, laravel-echo-server is sending a request to the apps (/broadcasting/auth). The user agent being empty and the remote address being the laravel-echo-server, the session is updated with the new info, which can cause a problem when using database sessions.

Here is an example problem :
https://laracasts.com/discuss/channels/laravel/user-session-user-agent-and-ip-address-fields-are-corrupt-when-using-laravel-echo-server

My suggestion is to add an X-Forwarded-For with the remote client IP and add the User-Agent.

To get the correct client IP address on the laravel side, we need to set up the laravel-echo-server IP address as a trusted proxy.
https://laravel.com/docs/master/requests#configuring-trusted-proxies
