### PR TITLE
Update redis-subscriber.ts

### DIFF
--- a/src/subscribers/redis-subscriber.ts
+++ b/src/subscribers/redis-subscriber.ts
@@ -55,6 +55,7 @@ export class RedisSubscriber implements Subscriber {
 
             this._redis.psubscribe(`${this._keyPrefix}*`, (err, count) => {
                 if (err) {
+                    Log.info(err);
                     reject('Redis could not subscribe.')
                 }
 


### PR DESCRIPTION
Add error info on 'Redis could not subscribe'
 (allow me to fix a bug with redis 7 (have to add subscribe permission on default user)