### PR TITLE
By default insecure TLS v1 and v1.1 are now disabled

### DIFF
--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -30,7 +30,7 @@ export class EchoServer {
         port: 6001,
         protocol: "http",
         socketio: {},
-        secureOptions: constants.SSL_OP_NO_TLSv1,
+        secureOptions: constants.SSL_OP_NO_TLSv1 | constants.SSL_OP_NO_TLSv1_1,
         sslCertPath: '',
         sslKeyPath: '',
         sslCertChainPath: '',


### PR DESCRIPTION
This disables TLS 1.0 and 1.1 to be disabled by default. To allow them, you can override this option with an empty string.